### PR TITLE
Zicntr was inside Zicsr file

### DIFF
--- a/rv32_zicntr
+++ b/rv32_zicntr
@@ -1,0 +1,4 @@
+$pseudo_op rv_zicsr::csrrs  rdcycleh   rd 19..15=0 31..20=0xC80 14..12=2 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrs  rdtimeh    rd 19..15=0 31..20=0xC81 14..12=2 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrs  rdinstreth rd 19..15=0 31..20=0xC82 14..12=2 6..2=0x1C 1..0=3
+

--- a/rv_zicntr
+++ b/rv_zicntr
@@ -1,0 +1,5 @@
+#rv_zicntr instructions
+$pseudo_op rv_zicsr::csrrs  rdcycle    rd 19..15=0 31..20=0xC00 14..12=2 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrs  rdtime     rd 19..15=0 31..20=0xC01 14..12=2 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrs  rdinstret  rd 19..15=0 31..20=0xC02 14..12=2 6..2=0x1C 1..0=3
+

--- a/rv_zicsr
+++ b/rv_zicsr
@@ -13,11 +13,5 @@ $pseudo_op rv_zicsr::csrrw  fsrm       rd rs1      31..20=0x002 14..12=1 6..2=0x
 $pseudo_op rv_zicsr::csrrwi fsrmi      rd zimm     31..20=0x002 14..12=5 6..2=0x1C 1..0=3
 $pseudo_op rv_zicsr::csrrw  fscsr      rd rs1      31..20=0x003 14..12=1 6..2=0x1C 1..0=3
 $pseudo_op rv_zicsr::csrrs  frcsr      rd 19..15=0 31..20=0x003 14..12=2 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrs  rdcycle    rd 19..15=0 31..20=0xC00 14..12=2 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrs  rdtime     rd 19..15=0 31..20=0xC01 14..12=2 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrs  rdinstret  rd 19..15=0 31..20=0xC02 14..12=2 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrs  rdcycleh   rd 19..15=0 31..20=0xC80 14..12=2 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrs  rdtimeh    rd 19..15=0 31..20=0xC81 14..12=2 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrs  rdinstreth rd 19..15=0 31..20=0xC82 14..12=2 6..2=0x1C 1..0=3
 
 


### PR DESCRIPTION
Even though, Zicntr depends on Zicsr, I think that separating their instructions in different files would allow for easier parsing when use cases of this repo actually need extension names. Aditionally, the "H" only exist when XLEN == 32, so it needs its own file. 